### PR TITLE
PVC mount path now alligns with default value of the following system…

### DIFF
--- a/resources/rhpam/rhpam-dev-business-central.yaml
+++ b/resources/rhpam/rhpam-dev-business-central.yaml
@@ -86,7 +86,7 @@ items:
               memory: "{{ businesscentral_memory_limit }}"
           volumeMounts:
           - name: "{{ businesscentral_application_name }}-pvol"
-            mountPath: "/opt/eap/standalone/data/kie"
+            mountPath: "/opt/kie/data"
           livenessProbe:
             exec:
               command:

--- a/resources/rhpam/rhpam-dev-business-central_sso.yaml
+++ b/resources/rhpam/rhpam-dev-business-central_sso.yaml
@@ -86,7 +86,7 @@ items:
               memory: "{{ businesscentral_memory_limit }}"
           volumeMounts:
           - name: "{{ businesscentral_application_name }}-pvol"
-            mountPath: "/opt/eap/standalone/data/kie"
+            mountPath: "/opt/kie/data"
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
… properties:  org.uberfire.nio.git.dir    &  org.uberfire.nio.git.ssh.cert.dir.    Subsequently,  version controlled business assets now survive restart of business central